### PR TITLE
remove unnecessary code for object alive checking

### DIFF
--- a/MTHawkeye/MemoryPlugins/LivingObjectSniffer/Core/UIView+MTHLivingObjectSniffer.m
+++ b/MTHawkeye/MemoryPlugins/LivingObjectSniffer/Core/UIView+MTHLivingObjectSniffer.m
@@ -102,37 +102,7 @@
 }
 
 - (BOOL)mth_shouldObjectAlive {
-    BOOL shouldBeAlive = NO;
-
-    if (self.window != nil) {
-        shouldBeAlive = YES;
-    }
-
-    if (!shouldBeAlive && self.superview != nil && self.window != nil) {
-        shouldBeAlive = YES;
-    }
-
-    if (!shouldBeAlive) {
-        UIResponder *responder = self.nextResponder;
-        while (responder) {
-            if (responder.nextResponder == nil) {
-                break;
-            } else {
-                responder = responder.nextResponder;
-            }
-
-            if ([responder isKindOfClass:[UIViewController class]]) {
-                break;
-            }
-        }
-
-        // if controller is active, view should be considered alive too.
-        if ([responder isKindOfClass:[UIViewController class]]) {
-            shouldBeAlive = YES;
-        }
-    }
-
-    return shouldBeAlive;
+    return [super mth_shouldObjectAlive];
 }
 
 @end

--- a/MTHawkeye/MemoryPlugins/LivingObjectSniffer/Core/UIViewController+MTHLivingObjectSniffer.m
+++ b/MTHawkeye/MemoryPlugins/LivingObjectSniffer/Core/UIViewController+MTHLivingObjectSniffer.m
@@ -122,29 +122,7 @@ static const void *const kMTHawkeyeViewControllerWillDealloc = &kMTHawkeyeViewCo
 }
 
 - (BOOL)mth_shouldObjectAlive {
-    if (![self isViewLoaded])
-        return NO;
-
-    BOOL shouldAlive = YES;
-    BOOL visibleOnScreen = NO;
-
-    UIView *v = self.view.window;
-
-    if ([v isKindOfClass:[UIWindow class]]) {
-        visibleOnScreen = YES;
-    }
-
-    BOOL beingHeld = NO;
-    if (self.navigationController != nil || self.presentingViewController != nil || self.tabBarController != nil) {
-        beingHeld = YES;
-    }
-
-    // not visible, not in view stack.
-    if (visibleOnScreen == NO && beingHeld == NO) {
-        shouldAlive = NO;
-    }
-
-    return shouldAlive;
+    return [super mth_shouldObjectAlive];
 }
 
 @end


### PR DESCRIPTION
there is no need  to bring in new logic to check alive of UIView or UIViewController 's instance, for you have already check it at the beginning of sniffer action