### PR TITLE
fix crash when detecting  leaks of a class

### DIFF
--- a/MTHawkeye/MemoryPlugins/LivingObjectSniffer/Core/NSObject+MTHLivingObjectSniffer.mm
+++ b/MTHawkeye/MemoryPlugins/LivingObjectSniffer/Core/NSObject+MTHLivingObjectSniffer.mm
@@ -38,7 +38,7 @@
 #ifdef MTHLivingObjectDebug
     MTHLogDebug(@" mth_castShadowOver: %@:%@", [self class], self);
 #endif
-    if (mtha_addr_is_in_sys_libraries((vm_address_t)self.class) || [self isKindOfClass:[MTHLivingObjectGroupInClass class]]) {
+    if (object_isClass(self) || mtha_addr_is_in_sys_libraries((vm_address_t)self.class) || [self isKindOfClass:[MTHLivingObjectGroupInClass class]]) {
         return NO;
     }
 


### PR DESCRIPTION
```
Class curLevelClass = self.class;
```
sending class method to a class will return itself. 

it will cause a crash  if self is a class:

```
id obj = object_getIvar(self, ivar);
```