### PR TITLE
fix anr_anr_tracing_buffer file may not create issue

### DIFF
--- a/MTHawkeye/TimeConsumingPlugins/ANRTrace/HawkeyeCore/MTHANRHawkeyeAdaptor.m
+++ b/MTHawkeye/TimeConsumingPlugins/ANRTrace/HawkeyeCore/MTHANRHawkeyeAdaptor.m
@@ -96,7 +96,11 @@
 
     // enable anr trace buffer, needed for tracing hard stall(stall then killed by watchdog or user)
     if (![MTHANRTracingBufferRunner isTracingBufferRunning]) {
-        NSString *path = [[MTHawkeyeUtility currentStorePath] stringByAppendingPathComponent:@"anr_tracing_buffer"];
+        NSString *storagePath = [MTHawkeyeUtility currentStorePath];
+        if (![[NSFileManager defaultManager] fileExistsAtPath:storagePath]) {
+            [MTHawkeyeStorage shared];
+        }
+        NSString *path = [storagePath stringByAppendingPathComponent:@"anr_tracing_buffer"];
         [MTHANRTracingBufferRunner enableTracingBufferAtPath:path];
     }
 

--- a/doc/time-consuming/anr-tracer-cn.md
+++ b/doc/time-consuming/anr-tracer-cn.md
@@ -40,7 +40,7 @@
 
 ## 0x03 存储说明
 
-ANR 的数据存储在 [Records 文件](./../hawkeye-storage-cn.md#0x02-内置插件存储数据说明) 下。`collection` 为 `anr`，`key` 为卡顿时间结束的时间点，`value` 为 json 字符串，字段说明如下：
+ANR 的数据存储在 [Records 文件](./../hawkeye-storage-cn.md#0x02-内置插件存储数据说明) 下。`collection` 为 `anr`，`key` 为卡顿时间结束的时间点（0.12.1之后的版本对它进行了优化，会拆分>16kb以上的卡顿数据再存储，`key`会变成`卡顿时间戳_序号`，当外部使用的时候需要进行数据合并，请参考`readANRRecords`中的合并方式）`value` 为 json 字符串，字段说明如下：
 - `duration`: 卡顿总时长（毫秒）
 - `inBackground`: 是否运行在后台
 - `stacks`: 卡顿周期内记录到的主线程堆栈

--- a/doc/time-consuming/anr-tracer.md
+++ b/doc/time-consuming/anr-tracer.md
@@ -26,7 +26,7 @@ When the app run into hard stall, it may killed without any logs, you can use `M
 
 ## 0x03 Storage
 
-ANR records is store under [Records file](./../hawkeye-storage.md#0x02-built-in-plugin-data-storage-instructions). Use a `collection` name `anr`, `key` as the time stalling event generated, `value` is a JSON string with the following fields:
+ANR records is store under [Records file](./../hawkeye-storage.md#0x02-built-in-plugin-data-storage-instructions). Use a `collection` name `anr`, `key` as the time stalling event generated (The version after 0.12.1 optimizes it, it will split the >16kb or more of the Carton data and store it again. The `key` will become the `timestamp_serial number`, which needs to be merged when used externally. Please refer to the merge method in `readANRRecords`), `value` is a JSON string with the following fields:
 
 - `duration`: stalling duration, in millisecond
 - `inBackground`: whether it is running in the background


### PR DESCRIPTION
某种情况下，这个方法比[MTHawkeyeStorage shared]调用得早导致目录未创建使得文件创建失败