### PR TITLE
`CocoaLumberjack` must <~3.6.0

### DIFF
--- a/MTHawkeyeDemo/Podfile.lock
+++ b/MTHawkeyeDemo/Podfile.lock
@@ -234,7 +234,7 @@ PODS:
 DEPENDENCIES:
   - AFNetworking
   - AGAsyncTestHelper/Shorthand
-  - CocoaLumberjack
+  - CocoaLumberjack (= 3.6.0)
   - FBRetainCycleDetector
   - fishhook
   - FLEX
@@ -271,6 +271,6 @@ SPEC CHECKSUMS:
   MTGLDebug: 4883ba4da36f45a88e2c2d805d2b5a5b54ba5ad1
   MTHawkeye: 24ba418f82648958e5ff150f99740120de9b25b5
 
-PODFILE CHECKSUM: d772bcb03da95f4f4008f493d829ba2e9bda6f98
+PODFILE CHECKSUM: 725e255d14f69beedecf156fbe831f168a664119
 
 COCOAPODS: 1.8.4

--- a/MTHawkeyeDemo/podfile
+++ b/MTHawkeyeDemo/podfile
@@ -17,7 +17,7 @@ def hawkeye
   pod 'FLEX'#, :configurations => ['Debug']
   pod 'FBRetainCycleDetector'#, :configurations => ['Debug']
   pod 'fishhook'#, :configurations => ['Debug']
-  pod 'CocoaLumberjack'#, :configurations => ['Debug'] # CocoaLumberjack is optional, change to `MTHawkeye/DefaultPluginsWithoutLog` if don't need.
+  pod 'CocoaLumberjack', '3.6.0' #, :configurations => ['Debug'] # CocoaLumberjack is optional, change to `MTHawkeye/DefaultPluginsWithoutLog` if don't need.
   pod 'MTGLDebug'#, :configurations => ['Debug'] # MTGLDebug is exclude by default, change `MTHawkeye` to `MTHawkeye/DefaultPlugins` to include.
 
   pod 'MTAppenderFile', '~> 0.4.0'#, :configurations => ['Debug'], :inhibit_warnings => false

--- a/Readme-cn.md
+++ b/Readme-cn.md
@@ -135,7 +135,8 @@ MTHawkeye 插件扩展支持了沙盒文件的 AirDrop 功能。
     pod 'FLEX', :configurations => ['Debug']
     pod 'FBRetainCycleDetector', :configurations => ['Debug']
     pod 'fishhook', :configurations => ['Debug']
-    pod 'CocoaLumberjack', :configurations => ['Debug'] # CocoaLumberjack is optional, change to `MTHawkeye/DefaultPluginsWithoutLog` if don't need.
+    pod 'CocoaLumberjack', 
+    '3.6.0', :configurations => ['Debug'] # CocoaLumberjack is optional, change to `MTHawkeye/DefaultPluginsWithoutLog` if don't need.
     # pod 'MTGLDebug', :configurations => ['Debug'] # MTGLDebug is exclude by default, change `MTHawkeye` to `MTHawkeye/DefaultPlugins` to include.
 
     pod 'MTAppenderFile', :configurations => ['Debug']
@@ -147,7 +148,7 @@ MTHawkeye 插件扩展支持了沙盒文件的 AirDrop 功能。
     # ...
   end
 ```
-
+注意：`CocoaLumberjack`这个依赖库需要使用<~3.6.0版本。
 然后，在应用启动时开启 MTHawkeye 服务。可以使用默认集成的所有插件，或者选择自己需要的插件启动。
 
 A: 快速集成默认的所有插件:

--- a/Readme.md
+++ b/Readme.md
@@ -141,7 +141,8 @@ First, add an MTHawkeye reference to the project podfile:
     pod 'FLEX', :configurations => ['Debug']
     pod 'FBRetainCycleDetector', :configurations => ['Debug']
     pod 'fishhook', :configurations => ['Debug']
-    pod 'CocoaLumberjack', :configurations => ['Debug'] # CocoaLumberjack is optional, change to `MTHawkeye/DefaultPluginsWithoutLog` if don't need.
+    pod 'CocoaLumberjack',
+    '3.6.0', :configurations => ['Debug'] # CocoaLumberjack is optional, change to `MTHawkeye/DefaultPluginsWithoutLog` if don't need.
     # pod 'MTGLDebug', :configurations => ['Debug'] # MTGLDebug is exclude by default, change `MTHawkeye` to `MTHawkeye/DefaultPlugins` to include.
 
     pod 'MTAppenderFile', :configurations => ['Debug']
@@ -153,6 +154,7 @@ First, add an MTHawkeye reference to the project podfile:
     # ...
   end
 ```
+Attention：`CocoaLumberjack` must <~3.6.0
 
 Then, turn on the MTHawkeye service when the App starts, You can use all the plugins as default, or choose the plugins you need to start.
 
@@ -231,7 +233,6 @@ There may be special requirements during the test phase, or may not need to reta
 ```ruby
   pod 'YourOnlineHawkeye', :podspec => 'xxx/yourOwnHawkeyeOnline.podspec', :configurations => 'Release'
 ```
-
 Then in the initialization, load the plugin as your needs, configure whether the plugin should start. such as
 
 ```objc


### PR DESCRIPTION
这个库3.6.1依赖的DDTTYLogger有API变动导致编译失败，故在podfile中指定为3.6.0版本